### PR TITLE
Workaround for Safari using transactions

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function initStorage(loadhook) {
   req.onsuccess = function() {
     var db = req.result;
 
-    var tx = db.transaction(['procedures', 'history']);
+    var tx = db.transaction('procedures');
     tx.objectStore('procedures').openCursor().onsuccess = function(e) {
       var cursor = e.target.result;
       if (cursor) {
@@ -81,6 +81,7 @@ function initStorage(loadhook) {
         }
       }
     };
+    tx = db.transaction('history');
     tx.objectStore('history').openCursor().onsuccess = function(e) {
       var cursor = e.target.result;
       if (cursor) {


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=136937 describes a bug where the implementation of IndexedDB throws errors for transactions using multiple object stores. In essence you cannot do `tx = db.transaction(['obj1', 'obj2'])`. This workaround passes all unit tests on Safari 8, Chrome 44, and FF 39.