### PR TITLE
Implemented `setcursor`

### DIFF
--- a/index.css
+++ b/index.css
@@ -176,10 +176,13 @@ body {
 
 #overlay {
   left: 0; top: 0; right: 0; bottom: 0;
+  z-index: 2;
+}
+
+.cursor {
   padding: 10px;
   margin: 0;
   position: absolute;
-  z-index: 2;
   background-color: transparent;
   overflow: hidden;
   white-space: pre-wrap;

--- a/index.htm
+++ b/index.htm
@@ -41,7 +41,7 @@
         <span>Your browser does not support the canvas element - sorry!</span>
       </canvas>
       <canvas id="turtle" width="450" height="250"></canvas>
-      <div id="overlay"></div>
+      <div id="overlay" class="cursor"></div>
       <div id="error"></div>
     </div>
   </div>

--- a/index.js
+++ b/index.js
@@ -499,6 +499,7 @@ function removeSnippet(parent, key) {
 window.addEventListener('load', function() {
 
   var stream = {
+    cursor: 0,
     read: function(s) {
       return window.prompt(s ? s : "");
     },
@@ -512,10 +513,28 @@ window.addEventListener('load', function() {
     clear: function() {
       var div = $('#overlay');
       div.innerHTML = "";
+      for (var i = this.cursor; i > 0; i -= 1){
+        div = $("#overlay" + i);
+        div.remove();
+      }
+      this.cursor = 0;
     },
     readback: function() {
       var div = $('#overlay');
       return div.innerHTML;
+    },
+    setcursor: function(x, y){
+      var canvas_x_coord = x % $('#sandbox').width;
+      var canvas_y_coord = y % $('#sandbox').height;
+
+      this.cursor += 1;
+      var prev_cursor = $('#overlay').cloneNode(true);
+      prev_cursor.id = $('#overlay').id + this.cursor;
+      $('#overlay').parentElement.appendChild(prev_cursor);
+
+      $('#overlay').style.top = canvas_y_coord + "px";
+      $('#overlay').style.left = canvas_x_coord + "px";
+      $('#overlay').innerHTML = "";
     }
   };
 

--- a/logo.js
+++ b/logo.js
@@ -1320,6 +1320,11 @@ function LogoInterpreter(turtle, stream, savehook)
   });
 
   // Not Supported: setcursor
+  def("setcursor", function(vector) {
+    // a vector is just a list
+    list = lexpr(vector);
+    self.stream.setcursor(list[0], list[1]);
+  });
   // Not Supported: cursor
   // Not Supported: setmargins
   // Not Supported: settextcolor


### PR DESCRIPTION
`setcursor` allows you set a vector from which Logo will begin outputting from while preserving previous text outputs. This implementation clones new nodes based upon `#overlay` and renders them within the confines of the display context (i.e. `<canvas>`). The behavior of `cleartext` has been modified to account for this new rendering behavior.

Not to sure how to write a unit test for this. Also not sure if the assumption that a passed in vector is just a two element-primitive list is the correct one.