### PR TITLE
Run on Ctrl+Enter in Multi-Line input

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,6 +292,23 @@ function initInput() {
     $('#logo-ta-multi-line + .CodeMirror').id = 'logo-cm-multi-line';
     cm2.setSize('100%', '100%');
 
+    // Handle ctrl+enter in Multi-Line
+    cm2.on('keydown', function(x, e) {
+        switch(e.keyCode)
+        {
+          case 3:
+          case 10:
+          case 13:
+            if(e.ctrlKey)
+            {
+              e.stopPropagation();
+              e.preventDefault();
+              run();
+            }
+            break;
+        }
+    });
+
     input.getValue = function() {
       return (isMulti() ? cm2 : cm).getValue();
     };


### PR DESCRIPTION
Using this with a book to teach my nephew to code. Found it a bit annoying that I had to use the mouse to run the code, instead of pressing ctrl+enter, which is a thing some places.

So, I tried to add it myself, and from what I can see, it works great!

I am however not sure if where I added this is where it should be added, or whether there are "better" ways to do it with what you're using. Not super-pro at JS stuff... 🤔