### PR TITLE
Fix handling of for loop limits in boundary cases.

### DIFF
--- a/logo.js
+++ b/logo.js
@@ -3252,6 +3252,11 @@ function LogoInterpreter(turtle, stream, savehook)
       })
       .then(function(r) {
         limit = aexpr(r);
+        return control.length ?
+          evaluateExpression(control) : (limit < start ? -1 : 1);
+      })
+      .then(function(r) {
+        step = aexpr(r);
       })
       .then(function() {
         return promiseLoop(function(loop, resolve, reject) {
@@ -3262,11 +3267,6 @@ function LogoInterpreter(turtle, stream, savehook)
           setvar(varname, current);
           this.execute(statements)
             .then(function() {
-              return (control.length) ?
-                evaluateExpression(control.slice()) : sign(limit - start);
-            })
-            .then(function(result) {
-              step = aexpr(result);
               current += step;
             })
             .then(promiseYield)

--- a/tests.js
+++ b/tests.js
@@ -1522,7 +1522,7 @@ QUnit.test("Workspace Management", function(t) {
 });
 
 QUnit.test("Control Structures", function(t) {
-  t.expect(107);
+  t.expect(112);
   //
   // 8.1 Control
   //
@@ -1628,6 +1628,13 @@ QUnit.test("Control Structures", function(t) {
 
   this.assert_equals('make "x 0  for [ r 10 0 -2 ] [ make "x :x + :r ]  :x', 30);
   this.assert_equals('make "x 0  for [ r 10 0 -2-2 ] [ make "x :x + :r ]  :x', 18);
+
+  this.assert_equals('make "x 0  for [ r 10 10 ] [ make "x :x + :r ]  :x', 10);
+  this.assert_equals('make "x 0  for [ r 10 10 1 ] [ make "x :x + :r ]  :x', 10);
+  this.assert_equals('make "x 0  for [ r 10 10 -1 ] [ make "x :x + :r ]  :x', 10);
+
+  this.assert_equals('make "x 0  for [ r 10 20 -1 ] [ make "x :x + :r ]  :x', 0);
+  this.assert_equals('make "x 0  for [ r 20 10 1 ] [ make "x :x + :r ]  :x', 0);
 
   this.assert_equals('make "x 0  do.while [ make "x :x + 1 ] :x < 10  :x', 10);
   this.assert_equals('make "x 0  do.while [ make "x :x + 1 ] [:x < 10]  :x', 10);
@@ -1787,7 +1794,7 @@ QUnit.test("Error Messages", function(t) {
 
 QUnit.test("Regression Tests", function(t) {
   this.assert_equals('make "x 0  repeat 3 [ for [ i 1 4 ] [ make "x :x + 1 ] ]  :x', 12);
-  this.assert_equals('make "x 0  for [i 0 100 :i + 1] [make "x :x + :i]  :x', 120);
+  this.assert_equals('make "i 5  make "x 0  for [ i 0 100 :i ] [ make "x :x + :i ]  :x', 1050);
   this.assert_error("fd 100 50 rt 90", "Don't know what to do with 50");
   this.assert_equals("to foo output 123 end  make \"v foo", undefined);
   this.assert_equals("to foo end", undefined);


### PR DESCRIPTION
- The step parameter needs to default to a non-zero value when
  start == limit, Otherwise, the following does not print anything (but
  *should* print "1"):

    ```
    for [i 1 1] [ print :i ]  ; This *should* print "1".
    ```

- The step parameter also needs to be evaluated before entering the
  loop. Otherwise, it takes on the value 0 during the first test. This
  causes the following two lines to print nothing (they *should* both
  print "1"):

    ```
    for [i 1 1 1] [ print :i ]  ; This *should* print "1".
    for [i 1 1 -1] [ print :i ]  ; This *should* print "1".
    ```

  And also causes the following to run through the loop once, printing
  the start value (they *should* print nothing):

    ```
    for [i 1 2 -1] [ print :i ]  ; This *should* print nothing.
    for [i 2 1 1] [ print :i ]  ; This *should* print nothing.
    ```