### PR TITLE
Allow filled to use logocolors or rgb values.

### DIFF
--- a/logo.js
+++ b/logo.js
@@ -2200,7 +2200,7 @@ function LogoInterpreter(turtle, stream, savehook)
   def("fill", function() { turtle.fill(); });
 
   def("filled", function(fillcolor, statements) {
-    fillcolor = sexpr(fillcolor);
+    fillcolor = parseColor(fillcolor);
     statements = reparse(lexpr(statements));
     turtle.beginpath();
     return promiseFinally(


### PR DESCRIPTION
Was working on some Logo code that I'd been testing in both UCBLogo and jslogo, and noticed that jslogo could only use color strings for 'filled'. Modified to use any of the color formats.