### PR TITLE
fix empty language menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -713,6 +713,7 @@ window.addEventListener('DOMContentLoaded', function() {
       .catch(function(reason) {
         console.warn('Error loading localization file for "' +
                      lang + '": ' + reason.message);
+        document.body.lang = 'en';
       });
   }());
 


### PR DESCRIPTION
Empty language menu is displayed when the page is opened in a browser with an unsupported preferred language. This PR will select *English* in the language input field when translation cannot be loaded.