### PR TITLE
Replacing bfoit.org with guyhaas.com/bfoit

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,7 +118,7 @@
       <li><a target="_blank" href="https://www.cs.berkeley.edu/~bh/logo.html">Berkeley Logo (UCBLogo)</a> is a well respected freeware interpreter
       <li><a target="_blank" href="http://blog.ianbicking.org/2007/10/19/logo/">Ian Bicking on Logo</a>
       <li><a target="_blank" href="http://pylogo.sourceforge.net/">PyLogo</a> is a sweet interpreter in Python
-      <li><a target="_blank" href="http://www.bfoit.org/itp/itp.html">Introduction to Computer Programming</a> using Logo
+      <li><a target="_blank" href="http://guyhaas.com/bfoit/itp/">Introduction to Computer Programming</a> using Logo
       <li><a target="_blank" href="http://groups.yahoo.com/group/LogoForum/">LogoForum</a> - a group for Logo programming discussions
       </ul>
       <p style="margin-top: 2em;">


### PR DESCRIPTION
The link on the site is broken, but googling produces this likely replacement candidate 