### PR TITLE
Skip extra lines when using penup within filled

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -989,7 +989,7 @@ QUnit.test("Logical Operations", function(t) {
 });
 
 QUnit.test("Graphics", function(t) {
-  t.expect(158);
+  t.expect(162);
 
   // NOTE: test canvas is 300,300 (so -150...150 coordinates before hitting)
   // edge
@@ -1070,6 +1070,13 @@ QUnit.test("Graphics", function(t) {
       [150 + 90, 150, red],
     ]);
   }.bind(this));
+
+  this.assert_pixels('cs  pd  filled "black [ fd 100 pu bk 100 rt 90 fd 100 pd lt 90 fd 100 ]', [
+    [150 + 25, 150 - 50, black],
+    [150 + 75, 150 - 50, black],
+    [150 + 50, 150 - 25, white],
+    [150 + 50, 150 - 75, white],
+  ]);
 
   //
   // 6.2 Turtle Motion Queries

--- a/turtle.js
+++ b/turtle.js
@@ -166,14 +166,16 @@
     _moveto: {value: function(x, y, setpos) {
 
       var _go = function(x1, y1, x2, y2) {
-        if (this.filling) {
-          this.canvas_ctx.lineTo(x1, y1);
-          this.canvas_ctx.lineTo(x2, y2);
-        } else if (this.pendown) {
-          this.canvas_ctx.beginPath();
-          this.canvas_ctx.moveTo(x1, y1);
-          this.canvas_ctx.lineTo(x2, y2);
-          this.canvas_ctx.stroke();
+        if (this.pendown) {
+          if (this.filling) {
+            this.canvas_ctx.lineTo(x1, y1);
+            this.canvas_ctx.lineTo(x2, y2);
+          } else {
+            this.canvas_ctx.beginPath();
+            this.canvas_ctx.moveTo(x1, y1);
+            this.canvas_ctx.lineTo(x2, y2);
+            this.canvas_ctx.stroke();
+          }
         }
       }.bind(this);
 


### PR DESCRIPTION
I was playing around with a custom `fdarc` procedure (which moves a specified distance along an arc of some angle), when I noticed that it doesn't work very well with `filled`, since it draws some extra strokes.

Examples:
```logo
; Two disconnected lines both going in the same direction
filled "black [ fd 100 pu bk 100 rt 90 fd 100 pd lt 90 fd 100 ]
```
```logo
; Two circle arcs going in opposite directions
cs filled "black [ arc 90 100 pu rt 45 bk 100 rt 45/2 pd arc -45 185 ]
```
```logo
; Eight circle arcs forming something similar to a compass rose
TO pi
  if not name? "_pi [ make "_pi (radarctan 0 1) * 2 ]
  output :_pi
END
TO fdarc :d :a
  localmake "r :d / ( :a * pi / 180 )
  if :r > 2000 [ fd :d lt :a stop ]
  if :r < -2000 [ fd :d lt :a stop ]
  ifelse pendown? [
    pu rt 90 bk :r pd ifelse :r > 0 [ arc -:a :r ] [ rt 180 arc -:a -:r rt 180 ] pu lt :a fd :r lt 90 pd
  ] [
    rt 90 bk :r lt :a fd :r lt 90
  ]
END
filled "black [ repeat 8 [ fdarc 100 45 rt 180 ] ]
```


Without `filled` | Without this PR | With PR
--- | --- | ---
![image](https://user-images.githubusercontent.com/5276727/100142259-473eb580-2e9c-11eb-8548-3b0c8431be48.png) | ![image](https://user-images.githubusercontent.com/5276727/100142280-50c81d80-2e9c-11eb-9a2b-caafc6c8a92e.png) | ![image](https://user-images.githubusercontent.com/5276727/100142312-5aea1c00-2e9c-11eb-9d00-6291d76faf57.png)
![image](https://user-images.githubusercontent.com/5276727/100142901-2fb3fc80-2e9d-11eb-8bdb-801f09231ebf.png) | ![image](https://user-images.githubusercontent.com/5276727/100142922-38a4ce00-2e9d-11eb-946a-91be84124dc1.png) | ![image](https://user-images.githubusercontent.com/5276727/100142954-3f334580-2e9d-11eb-8dbe-f3fe62e2a62a.png)
![image](https://user-images.githubusercontent.com/5276727/100141652-6d178a80-2e9b-11eb-9e1f-cb4faa5caaa2.png) | ![image](https://user-images.githubusercontent.com/5276727/100141619-6426b900-2e9b-11eb-934e-a65ec3cfc7d7.png) |  ![image](https://user-images.githubusercontent.com/5276727/100141739-8ae4ef80-2e9b-11eb-80a1-f1025df42ca6.png)

Note that the final example works fine even with the current implementation if one uses `penup` right at the end of `filled`. The second example is still messy in that case, though.
