### PR TITLE
Add sound API: beep

### DIFF
--- a/logo.js
+++ b/logo.js
@@ -3693,4 +3693,48 @@ function LogoInterpreter(turtle, stream, savehook)
       throw new Error("Internal error: Unbound procedure");
     return value;
   });
+
+  //----------------------------------------------------------------------
+  //
+  // Sound supports: basic sound / basic music / web speech
+  //
+  //----------------------------------------------------------------------
+
+  if ('AudioContext' in window) {
+    var audioCtx = new window.AudioContext();
+    var soundqueue = [];
+
+    function playSound(frequency, duration) {
+      // Adapted from:
+      // https://stackoverflow.com/questions/39200994/how-to-play-a-specific-frequency-with-javascript
+
+      var oscillator = audioCtx.createOscillator();
+
+      oscillator.type = 'square';
+      oscillator.frequency.value = frequency; // value in hertz
+      oscillator.connect(audioCtx.destination);
+      oscillator.start();
+
+      setTimeout(
+        function() {
+          oscillator.stop();
+          playSoundQ();
+        }, duration);
+    }
+
+    function playSoundQ() {
+      if (soundqueue.length > 0) {
+        var sound2play = soundqueue.pop();
+        playSound(sound2play[0], sound2play[1]);
+      }
+    }
+
+    // Play sound with a frequency and a time interval
+    def("beep", function(frequency, duration) {
+      var freq = aexpr(frequency),
+        dura = aexpr(duration);
+      soundqueue.push([freq, dura]);
+      playSoundQ();
+    });
+  }
 }

--- a/tests.js
+++ b/tests.js
@@ -1992,6 +1992,7 @@ QUnit.test("Arity of Primitives", function(t) {
     ['ashift', [2, 2, 2]],
     ['back', [1, 1, 1]],
     ['background', [0, 0, 0]],
+    ['beep', [2, 2, 2]],
     ['before?', [2, 2, 2]],
     ['beforep', [2, 2, 2]],
     ['bf', [1, 1, 1]],
@@ -2312,4 +2313,11 @@ QUnit.test("Arity of Primitives", function(t) {
     var arity = pair[1];
     this.assert_equals('arity "' + proc, arity);
   }.bind(this));
+});
+
+QUnit.test("Sound API", function(t) {
+  //
+  // Sound API
+  //
+  this.assert_equals('beep 220 1', undefined);
 });


### PR DESCRIPTION
add basic sound support to jslogo. In this first commit, only "beep" was supported.

**beep**

- beep frequency duration

frequency is in Hertz, and duration is in millisecond.

examples:
```logo
beep 330 200
```

